### PR TITLE
feat: Add getLayer method

### DIFF
--- a/packages/flame_tiled/example/lib/main.dart
+++ b/packages/flame_tiled/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flame_tiled/flame_tiled.dart';
 import 'package:flutter/widgets.dart' hide Animation, Image;
+import 'package:tiled/tiled.dart';
 
 void main() {
   runApp(GameWidget(game: TiledGame()));
@@ -15,9 +16,12 @@ class TiledGame extends FlameGame {
     final tiledMap = await TiledComponent.load('map.tmx', Vector2.all(16));
     add(tiledMap);
 
-    final objGroup = tiledMap.tileMap.getObjectGroupFromLayer('AnimatedCoins');
+    final objGroup = tiledMap.tileMap.getLayer<ObjectGroup>('AnimatedCoins');
     final coins = await Flame.images.load('coins.png');
-    for (final obj in objGroup.objects) {
+
+    // We are 100% sure that an object layer named `AnimatedCoins`
+    // exists in the example `map.tmx`.
+    for (final obj in objGroup!.objects) {
       add(
         SpriteAnimationComponent(
           position: Vector2(obj.x, obj.y),

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -202,33 +202,27 @@ class RenderableTiledMap {
 
   /// This returns an object group fetch by name from a given layer.
   /// Use this to add custom behaviour to special objects and groups.
+  @Deprecated('This method is deprecated. Use the getLayer() method instead.')
   ObjectGroup getObjectGroupFromLayer(String name) {
     final g = map.layers.firstWhere((layer) {
       return layer is ObjectGroup && layer.name == name;
     });
     return g as ObjectGroup;
   }
-  
-  //Adding getImageLayer
-  ImageLayer getImageLayer(String name) {
-    final i = map.layers.firstWhere((layer) {
-      return layer is ImageLayer && layer.name == name;
-    });
-    return i as ImageLayer;
+
+  /// Returns a layer of type [T] with given [name] from all the layers
+  /// of this map. If no such layer is found, null is returned.
+  T? getLayer<T extends Layer>(String name) {
+    T? foundLayer;
+
+    try {
+      foundLayer = map.layers.firstWhere((layer) {
+        return layer is T && layer.name == name;
+      }) as T;
+    } on StateError {
+      foundLayer = null;
+    }
+
+    return foundLayer;
   }
-  //Adding getTileLayer
-  TileLayer getTileLayer(String name) {
-    final t = map.layers.firstWhere((layer) {
-      return layer is TileLayer && layer.name == name;
-    });
-    return t as TileLayer;
-  }
-  //Adding getGroupLayer
-  Group getGroupLayer(String name) {
-    final g = map.layers.firstWhere((layer) {
-      return layer is Group && layer.name == name;
-    });
-    return g as Group;
-  }
-  
 }

--- a/packages/flame_tiled/test/assets/layers_test.tmx
+++ b/packages/flame_tiled/test/assets/layers_test.tmx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" width="10" height="6" tilewidth="32" tileheight="32" infinite="0" nextlayerid="5" nextobjectid="10">
+ <layer id="1" name="MyTileLayer" width="10" height="6">
+  <data encoding="base64">
+   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  </data>
+ </layer>
+ <objectgroup id="2" name="MyObjectLayer" offsetx="0" offsety="-32">
+  <object id="9" x="64" y="160" width="200" height="40">
+   <text wrap="1" color="#ffffff">Just a dummy map for 
+ testing layers</text>
+  </object>
+ </objectgroup>
+ <imagelayer id="3" name="MyImageLayer">
+  <image source="map-level1.png" width="272" height="128"/>
+ </imagelayer>
+ <group id="4" name="MyGroupLayer"/>
+</map>

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -8,6 +8,7 @@ import 'package:flame/flame.dart';
 import 'package:flame_tiled/flame_tiled.dart';
 import 'package:flutter/services.dart' show CachingAssetBundle;
 import 'package:test/test.dart';
+import 'package:tiled/tiled.dart';
 
 void main() {
   test('correct loads the file', () async {
@@ -121,6 +122,53 @@ void main() {
             leftTilePixels[indGreen + 3] == 255;
       }
       expect(allGreen, true);
+    });
+  });
+
+  group('Test getLayer:', () {
+    late RenderableTiledMap _renderableTiledMap;
+    setUp(() async {
+      Flame.bundle = TestAssetBundle(
+        imageNames: ['map-level1.png'],
+        mapPath: 'test/assets/layers_test.tmx',
+      );
+      _renderableTiledMap =
+          await RenderableTiledMap.fromFile('layers_test.tmx', Vector2.all(32));
+    });
+
+    test('Get Tile Layer', () {
+      expect(
+        _renderableTiledMap.getLayer<TileLayer>('MyTileLayer'),
+        isNotNull,
+      );
+    });
+
+    test('Get Object Layer', () {
+      expect(
+        _renderableTiledMap.getLayer<ObjectGroup>('MyObjectLayer'),
+        isNotNull,
+      );
+    });
+
+    test('Get Image Layer', () {
+      expect(
+        _renderableTiledMap.getLayer<ImageLayer>('MyImageLayer'),
+        isNotNull,
+      );
+    });
+
+    test('Get Group Layer', () {
+      expect(
+        _renderableTiledMap.getLayer<Group>('MyGroupLayer'),
+        isNotNull,
+      );
+    });
+
+    test('Get no layer', () {
+      expect(
+        _renderableTiledMap.getLayer<TileLayer>('Nonexistent layer'),
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
# Description
This PR adds a new generic `getLayer` method which can get all types of layers from the map. As this makes `getObjectGroupFromLayer` redundant, `getObjectGroupFromLayer` is now marked as `@Deprecated`. This new `getLayer` method also handles non-existent layer names as input more gracefully by returning null.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change, but it does mark one of the public method as `Deprecated`.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
